### PR TITLE
Add note on why we're passing a regular function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Ghosty.create(ph => {
             // => Opened google?  success
 
             // Get the document title
+            // We're passing a regular function here because
+            // ES6 arrow functions are not yet supported on PhantomJS
             page.evaluate(function () { return document.title; }, result => {
                 console.log('Page title is ' + result);
                 // => Page title is Google

--- a/example/index.js
+++ b/example/index.js
@@ -13,6 +13,8 @@ Ghosty.create(ph => {
             // => Opened google?  success
 
             // Get the document title
+            // We're passing a regular function here because
+            // ES6 arrow functions are not yet supported on PhantomJS
             page.evaluate(function () { return document.title; }, result => {
                 console.log('Page title is ' + result);
                 // => Page title is Google


### PR DESCRIPTION
As pointed out on https://github.com/IonicaBizau/ghosty/pull/1#issuecomment-157014807:

> Thanks, but arrow functions are not yet supported on PhantomJS. That's why I didn't use them in the evaluate function.

Does this look OK :ok_hand:? I added a _supporting_ clause so the reader gets the context.
